### PR TITLE
added migrations to update the schema and fixed the seeds accordingly

### DIFF
--- a/db/migrate/20180822124334_remove_price_from_measurement_shopping_lists.rb
+++ b/db/migrate/20180822124334_remove_price_from_measurement_shopping_lists.rb
@@ -1,0 +1,5 @@
+class RemovePriceFromMeasurementShoppingLists < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :measurement_shopping_lists, :price, :float
+  end
+end

--- a/db/migrate/20180822124509_remove_unit_from_measurements.rb
+++ b/db/migrate/20180822124509_remove_unit_from_measurements.rb
@@ -1,0 +1,5 @@
+class RemoveUnitFromMeasurements < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :measurements, :unit, :string
+  end
+end

--- a/db/migrate/20180822124939_add_columns_to_ingredients.rb
+++ b/db/migrate/20180822124939_add_columns_to_ingredients.rb
@@ -1,0 +1,6 @@
+class AddColumnsToIngredients < ActiveRecord::Migration[5.2]
+  def change
+    add_column :ingredients, :price, :float
+    add_column :ingredients, :unit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_20_131319) do
+ActiveRecord::Schema.define(version: 2018_08_22_124939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,8 @@ ActiveRecord::Schema.define(version: 2018_08_20_131319) do
     t.boolean "base"
     t.boolean "topping"
     t.boolean "seasoning"
+    t.float "price"
+    t.string "unit"
     t.index ["ingredient_family_id"], name: "index_ingredients_on_ingredient_family_id"
   end
 
@@ -57,7 +59,6 @@ ActiveRecord::Schema.define(version: 2018_08_20_131319) do
     t.bigint "measurement_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.float "price"
     t.index ["measurement_id"], name: "index_measurement_shopping_lists_on_measurement_id"
     t.index ["shopping_list_id"], name: "index_measurement_shopping_lists_on_shopping_list_id"
   end
@@ -65,7 +66,6 @@ ActiveRecord::Schema.define(version: 2018_08_20_131319) do
   create_table "measurements", force: :cascade do |t|
     t.bigint "ingredient_id"
     t.bigint "recipe_id"
-    t.string "unit"
     t.float "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -181,6 +181,8 @@ urls.each do |url|
   counter = 0
   while counter < doc.search('.fela-bj2f19').length
     @ingredient = Ingredient.find_by(name: doc.search('.fela-c30jy9')[counter].text.strip)
+    measurements = doc.search('.fela-2htk9c')[counter].text.strip.split(" ")
+    given_price = [10, 25, 3, 18].sample
     @ingredient ||= Ingredient.new(
     {
       name: doc.search('.fela-c30jy9')[counter].text.strip,
@@ -190,7 +192,9 @@ urls.each do |url|
       ingredient_family_id: 2,
       base: false,
       topping: false,
-      seasoning: true
+      seasoning: true,
+      unit: measurements[1],
+      price: given_price
     },
     );
     @ingredient.save!
@@ -199,7 +203,6 @@ urls.each do |url|
       {
         ingredient_id: @ingredient.id,
         recipe_id: @recipe.id,
-        unit: measurements[1],
         value: measurements[0]
       },
     ]);
@@ -232,53 +235,43 @@ puts "Creating measurement shopping lists..."
 MeasurementShoppingList.create!([
   {
     shopping_list_id: 1,
-    measurement_id: 1,
-    price: 10
+    measurement_id: 1
   },
   {
     shopping_list_id: 1,
-    measurement_id: 2,
-    price: 10
+    measurement_id: 2
   },
   {
     shopping_list_id: 1,
-    measurement_id: 3,
-    price: 10
+    measurement_id: 3
   },
   {
     shopping_list_id: 1,
-    measurement_id: 4,
-    price: 10
+    measurement_id: 4
   },
   {
     shopping_list_id: 1,
-    measurement_id: 5,
-    price: 10
+    measurement_id: 5
   },
   {
     shopping_list_id: 1,
-    measurement_id: 86,
-    price: 20
+    measurement_id: 86
   },
   {
     shopping_list_id: 1,
-    measurement_id: 80,
-    price: 20
+    measurement_id: 80
   },
   {
     shopping_list_id: 1,
-    measurement_id: 81,
-    price: 20
+    measurement_id: 81
   },
   {
     shopping_list_id: 1,
-    measurement_id: 84,
-    price: 20
+    measurement_id: 84
   },
   {
     shopping_list_id: 1,
-    measurement_id: 33,
-    price: 20
+    measurement_id: 33
   },
   # this one has nil value
   # {
@@ -288,13 +281,11 @@ MeasurementShoppingList.create!([
   # },
   {
     shopping_list_id: 2,
-    measurement_id: 2,
-    price: 3
+    measurement_id: 2
   },
   {
     shopping_list_id: 3,
-    measurement_id: 2,
-    price: 5
+    measurement_id: 2
   }
 ]);
 puts "Created #{MeasurementShoppingList.all.length} measurements shopping lists"


### PR DESCRIPTION
The schema looks like this now:
<img width="1105" alt="schema" src="https://user-images.githubusercontent.com/39303357/44465037-aa39a600-a61c-11e8-9830-2215c310d6dd.png">

Price and unit of measure are moved into the ingredient table.
The seeds are updated.