### PR TITLE
Fix/use display names for ingredients

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -16,13 +16,21 @@ class Ingredient < ApplicationRecord
      Measurement.joins([:measurement_shopping_lists, :ingredient]).where("shopping_list_id = ?", shopping_list.id).where(ingredient_id: id).sum(:value)
   end
 
+  def relatives
+    Measurement.joins(:ingredient).where("ingredient_id = ?", id)
+  end
+
+   def relatives_in_shopping_list(shopping_list)
+    Measurement.joins(:ingredient, :measurement_shopping_lists).where("ingredient_id = ?", id).where("shopping_list_id = ?", shopping_list.id)
+  end
+
   # def total_price_in_shopping_list(shopping_list)
   #   self.price * self.total_amount_in_shopping_list(shopping_list)
   # end
 
-  def total_price_for_measurement(measurement)
-  measurement.value
-  end
+  # def total_price_for_measurement(measurement)
+  # measurement.value
+  # end
 
 end
 

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -16,7 +16,7 @@
       <div class="recipe-ingredients">
         <ul class="list-inline">
           <% @recipe.measurements.each do |measurement| %>
-          <li> <%= measurement.ingredient.name %> <%= measurement.value %> <%= measurement.ingredient.unit %></li>
+          <li> <%= measurement.display_name.capitalize %>  | <%= measurement.value %> <%= measurement.ingredient.unit %></li>
           <% end %>
         </ul>
       </div>

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -10,9 +10,28 @@
           <ul>
             <% @shopping_list.ingredients.each do |ingredient| %>
               <li>
-                <%= ingredient.name %> |
-                <%= ingredient.total_amount_in_shopping_list(@shopping_list) %>
-                <%= ingredient.unit %> |
+                <h5><%= ingredient.name.capitalize %></h5>
+                  <% unless ingredient.relatives_in_shopping_list(@shopping_list).length == 1 && ingredient.relatives_in_shopping_list(@shopping_list).first.display_name == ingredient.name %>
+                    <% ingredient.relatives_in_shopping_list(@shopping_list).each do |relative| %>
+                      <% unless ["salt", "pepper"].include?(ingredient.name) %>
+                        <ul>
+                          <li>
+                            <%= relative.display_name %>
+                            <% if relative.value  %>
+                              | <%= relative.value %>
+                              <%= ingredient.unit %>
+                            <% end %>
+                          </li>
+                        </ul>
+                      <% end %>
+                    <% end %>
+                    ------------ <br>
+                  <% end %>
+                <% if ingredient.total_amount_in_shopping_list(@shopping_list) != 0 %>
+                  Total:
+                  <%= ingredient.total_amount_in_shopping_list(@shopping_list) %>
+                  <%= ingredient.unit %>
+                <% end %>
               </li>
             <% end %>
           </ul>
@@ -38,13 +57,13 @@
                       <% if @shopping_list.measurements.include?(measurement) %>
 
                         <li>
-                          <%= measurement.ingredient.name %>
+                          <%= measurement.display_name.capitalize %>
                           <%= link_to "🗑️", measurement_shopping_list_path(measurement.measurement_for(@shopping_list)), method: :delete, data: {confirm: "Are you sure?"}, class: "shopping-list-recipe-card-remove" %>
                           <br>
 
                           <div class="shopping-list-recipe-card-values">
                             <%= measurement.value %>
-                            <%= measurement.ingredient.unit %> for
+                            <%= measurement.ingredient.unit %>
                           </div>
 
                         </li>

--- a/app/views/shopping_lists/show.html.erb
+++ b/app/views/shopping_lists/show.html.erb
@@ -11,6 +11,7 @@
             <% @shopping_list.ingredients.each do |ingredient| %>
               <li>
                 <h5><%= ingredient.name.capitalize %></h5>
+                <!-- if the ingredient has only one relative and their names are the same, then it won't display the relative's name -->
                   <% unless ingredient.relatives_in_shopping_list(@shopping_list).length == 1 && ingredient.relatives_in_shopping_list(@shopping_list).first.display_name == ingredient.name %>
                     <% ingredient.relatives_in_shopping_list(@shopping_list).each do |relative| %>
                       <% unless ["salt", "pepper"].include?(ingredient.name) %>
@@ -25,8 +26,10 @@
                         </ul>
                       <% end %>
                     <% end %>
+                    <!-- remove this when styling :) -->
                     ------------ <br>
                   <% end %>
+                <!-- do not display the value if it's zero (like in "flour for dusting") -->
                 <% if ingredient.total_amount_in_shopping_list(@shopping_list) != 0 %>
                   Total:
                   <%= ingredient.total_amount_in_shopping_list(@shopping_list) %>


### PR DESCRIPTION
• Fix all around to use display_names for ingredients
• Group the ingredients in the shopping list by "clean names" with varieties displayed below